### PR TITLE
Исправление captured dependency и добавление HTTP resilience

### DIFF
--- a/tests/KodySu.Client.Tests/CapturedDependencyTests.cs
+++ b/tests/KodySu.Client.Tests/CapturedDependencyTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace KodySu.Client.Tests;
+
+/// <summary>
+/// Тесты для проверки отсутствия проблем с captured dependencies
+/// </summary>
+public class CapturedDependencyTests
+{
+    [Fact]
+    public void KodySuClient_CanBeCreated_WithoutCapturedDependencies()
+    {
+        // Arrange - проверяем, что клиент может быть создан без captured dependencies
+        var configDict = new Dictionary<string, string?>
+        {
+            ["KodySuOptions:ApiKey"] = "test-key",
+            ["KodySuOptions:BaseUrl"] = "https://api.test.com",
+            ["KodySuOptions:TimeoutSeconds"] = "30",
+            ["KodySuOptions:UserAgent"] = "Test-Client/1.0"
+        };
+
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict)
+            .Build();
+
+        var services = new ServiceCollection();
+
+        // Добавляем клиент используя наш extension method
+        services.AddKodySuClient(configuration);
+
+        // Act & Assert - если есть captured dependency, то билд service provider выдаст исключение или клиент не создастся
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        IKodySuClient client = serviceProvider.GetRequiredService<IKodySuClient>();
+
+        // Проверяем, что клиент был корректно создан
+        client.Should().BeOfType<KodySuClient>();
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CachedKodySuClient_CanBeCreated_WithoutCapturedDependencies()
+    {
+        // Arrange - проверяем, что кешированный клиент может быть создан без captured dependencies
+        var configDict = new Dictionary<string, string?>
+        {
+            ["KodySuOptions:ApiKey"] = "test-key",
+            ["KodySuOptions:BaseUrl"] = "https://api.test.com",
+            ["KodySuOptions:TimeoutSeconds"] = "30",
+            ["KodySuOptions:UserAgent"] = "Test-Client/1.0"
+        };
+
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict)
+            .Build();
+
+        var services = new ServiceCollection();
+
+        // Добавляем кешированный клиент
+        services.AddCachedKodySuClient(configuration);
+
+        // Act & Assert - если есть captured dependency, то билд service provider выдаст исключение или клиент не создастся
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        IKodySuClient client = serviceProvider.GetRequiredService<IKodySuClient>();
+
+        // Проверяем, что клиент был корректно создан как кешированный
+        client.Should().BeOfType<CachedKodySuClient>();
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CachedKodySuClient_IsRegisteredAsScoped_NotSingleton()
+    {
+        // Arrange
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["KodySuOptions:ApiKey"] = "test-key",
+                ["KodySuOptions:BaseUrl"] = "https://api.test.com"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddCachedKodySuClient(configuration);
+
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Act & Assert - проверяем, что каждый scope получает свой экземпляр
+        using IServiceScope scope1 = serviceProvider.CreateScope();
+        using IServiceScope scope2 = serviceProvider.CreateScope();
+
+        IKodySuClient client1 = scope1.ServiceProvider.GetRequiredService<IKodySuClient>();
+        IKodySuClient client2 = scope2.ServiceProvider.GetRequiredService<IKodySuClient>();
+
+        // Должны быть разные экземпляры (Scoped lifetime)
+        client1.Should().NotBeSameAs(client2);
+
+        // Но в пределах одного scope - тот же экземпляр
+        IKodySuClient client1_again = scope1.ServiceProvider.GetRequiredService<IKodySuClient>();
+        client1.Should().BeSameAs(client1_again);
+    }
+}


### PR DESCRIPTION
## Проблема

При анализе кода обнаружены архитектурные проблемы в DI регистрации:

1. Антипаттерн **Captured Dependency**: В методах `AddKodySuClient` и `AddCachedKodySuClient` использовалось замыкание, которое захватывало `IOptions<KodySuClientOptions>` во время регистрации, что могло привести к устаревшим конфигурациям клиента и утечкам памяти.

2. **Отсутствие Resilience**: HTTP клиенты не имели встроенных retry-политик и circuit breaker для обработки временных сбоев сети.

3. **Неправильный Lifetime**: `CachedKodySuClient` был зарегистрирован как `Singleton`, что противоречит рекомендациям для типизированных HTTP клиентов.

4. **Неполная поддержка настроек**: Метод конфигурации HttpClient не документировал, какие настройки из `HttpClientOptions` поддерживаются.

## Решение

Выполнены архитектурные исправления с сохранением полной обратной совместимости API:

### Устранение захватываемой зависимости

```csharp
// ДО: Captured dependency
services.AddHttpClient<IKodySuClient, KodySuClient>()
    .ConfigureHttpClient((serviceProvider, httpClient) => {
        var options = serviceProvider.GetRequiredService<IOptions<KodySuClientOptions>>().Value;
        // closure захватывает serviceProvider
    });

// ПОСЛЕ: Правильный паттерн
services.AddHttpClient<IKodySuClient, KodySuClient>()
    .ConfigureHttpClient(ConfigureKodySuHttpClient)
    .AddResilience();

private static void ConfigureKodySuHttpClient(IServiceProvider serviceProvider, HttpClient httpClient)
{
    // Резолвим Options на каждый вызов - избегаем captured dependency
    var options = serviceProvider.GetRequiredService<IOptions<KodySuClientOptions>>().Value;
    // Конфигурация HttpClient
}
```

### Добавление HTTP Resilience

- Автоматические retry-политики (3 попытки с экспоненциальным backoff)
- Circuit breaker для предотвращения каскадных сбоев
- Умная обработка ошибок (5xx, timeouts, rate limits)

из "коробки" из [Reliable.HttpClient](https://www.nuget.org/packages/Reliable.HttpClient/#readme-body-tab).

### Исправление DI Lifetimes

`CachedKodySuClient` переведен с singleton на scoped для правильного управления зависимостями.

## Дополнительная информация

- Все 61 тест проходят без изменений
- Добавлены 3 новых теста для проверки DI регистрации (CapturedDependencyTests)
- Сохранена полная обратная совместимость API

---

Код готов к использованию в ПланФакте без изменений:

```csharp
services.AddCachedKodySuClient(configuration);
```

_TLDR; Все изменения внутренние, API остается стабильным. Пользователи получают улучшения автоматически._