### PR TITLE
feat: Добавлена поддержка Reliable.HttpClient 1.3.0 и Reliable.HttpClient.Caching 1.4.0

### DIFF
--- a/src/Planfact.KodySu.Client/CachedKodySuClient.cs
+++ b/src/Planfact.KodySu.Client/CachedKodySuClient.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using Reliable.HttpClient;
-using Reliable.HttpClient.Caching;
+using Reliable.HttpClient.Caching.Generic;
 
 namespace Planfact.KodySu.Client;
 
@@ -64,6 +64,7 @@ public sealed class CachedKodySuClient(
         {
             return Task.FromException<IReadOnlyList<KodySuResult>>(new ArgumentNullException(nameof(phoneNumbers)));
         }
+
         return SearchPhonesAsyncCore(phoneNumbers, cancellationToken);
     }
 

--- a/src/Planfact.KodySu.Client/KodySuServiceCollectionExtensions.cs
+++ b/src/Planfact.KodySu.Client/KodySuServiceCollectionExtensions.cs
@@ -3,8 +3,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Reliable.HttpClient;
-using Reliable.HttpClient.Caching;
 using Reliable.HttpClient.Caching.Extensions;
+using Reliable.HttpClient.Caching.Generic;
 
 namespace Planfact.KodySu.Client;
 

--- a/src/Planfact.KodySu.Client/Planfact.KodySu.Client.csproj
+++ b/src/Planfact.KodySu.Client/Planfact.KodySu.Client.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Reliable.HttpClient" Version="1.0.0" />
-    <PackageReference Include="Reliable.HttpClient.Caching" Version="1.0.2" />
+    <PackageReference Include="Reliable.HttpClient" Version="1.3.0" />
+    <PackageReference Include="Reliable.HttpClient.Caching" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,7 +45,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.8.2-beta.1"
-      PrivateAssets="All" />
+    <PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.8.2-beta.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tests/Planfact.KodySu.Client.Tests/CachedKodySuClientTests.cs
+++ b/tests/Planfact.KodySu.Client.Tests/CachedKodySuClientTests.cs
@@ -8,7 +8,7 @@ using Moq;
 using Moq.Protected;
 
 using Reliable.HttpClient;
-using Reliable.HttpClient.Caching;
+using Reliable.HttpClient.Caching.Generic;
 
 namespace Planfact.KodySu.Client.Tests;
 

--- a/tests/Planfact.KodySu.Client.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Planfact.KodySu.Client.Tests/ServiceCollectionExtensionsTests.cs
@@ -5,8 +5,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Reliable.HttpClient;
-using Reliable.HttpClient.Caching;
 using Reliable.HttpClient.Caching.Abstractions;
+using Reliable.HttpClient.Caching.Generic;
 
 namespace Planfact.KodySu.Client.Tests;
 


### PR DESCRIPTION
## Описание
В рамках данного PR были обновлены зависимости от пакетов `Reliable.HttpClient` и `Reliable.HttpClient.Caching`. Цель этих изменений состоит в поддержании совместимости клиента KodySu с проектами, использующими актуальные версии `Reliable.HttpClient`. Текущая версия `Reliable.HttpClient.Caching` (1.0.2) несовместима с `Reliable.HttpClient.Caching` 1.4.0 поскольку в актуальной версии класс `CachedHttpClient` был перемещен в пространство имен `Reliable.HttpClient.Caching.Generic`.

## Тип изменений
- [ ] Исправление ошибки
- [x] Новая функциональность
- [ ] Изменения, ломающие обратную совместимость
- [ ] Обновление документации

## Тестирование
- [ ] Я добавил тесты, подтверждающие работоспособность моего кода
- [x] Новые и существующие тесты успешно выполняются на моей машине

## Чеклист
- [x] Мой код соответствует соглашениям по стилю, принятым в данном проекте
- [ ] Я выполнил самостоятельное ревью изменений
- [ ] Я добавил комментарии в сложных и неявных местах
- [ ] Я внес необходимые изменения в документацию
- [x] Мой код не генерирует новых предупреждений